### PR TITLE
use subprocess.check_output to call jzarr test script

### DIFF
--- a/test/test_read_all.py
+++ b/test/test_read_all.py
@@ -77,35 +77,17 @@ READABLE_CODECS: Dict[str, Dict[str, List[str]]] = {
 }
 
 
-def execute(cmd):
-    """
-    Similar to subprocess.check_call but print stdout during execution.
-    """
-    popen = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        universal_newlines=True,
-        shell=True,
-    )
-
-    for stdout_line in iter(popen.stdout.readline, ""):
-        yield stdout_line
-
-    popen.stdout.close()
-    return_code = popen.wait()
-    if return_code:
-        raise subprocess.CalledProcessError(return_code, cmd)
-
-
 def read_with_jzarr(fpath, ds_name, nested=None):
-    execute(
-        [
-            "generate_data/jzarr/generate_data.sh",
-            "-verify",
-            str(fpath),
-            ds_name
-        ],
+    if ds_name == "blosc":
+        ds_name = "blosc/lz4"
+
+    cmd = (
+        f"generate_data/jzarr/generate_data.sh "
+        f"-verify {str(fpath)} {ds_name}"
     )
+
+    # will raise subprocess.CalledProcessError if return code is not 0
+    subprocess.check_output(cmd, shell=True)
     return None
 
 


### PR DESCRIPTION
I verified that the following is actually running the script and will fail if an invalid `ds_name` is given.

For example, if I call it with (nonexistent) `ds_name = 'raw2'` I get (I replaced a long local path with <DATA_PATH> for brevity):
```
CalledProcessError: Command 'generate_data/jzarr/generate_data.sh -verify '<DATA_PATH>/jzarr_flat.zr' raw2' returned non-zero exit status 2.
```